### PR TITLE
Health check

### DIFF
--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -16,6 +16,10 @@
                                                   ::cb/bucket "json"} 
                                        "fruit" {::cb/encoder :nippy
                                                 ::cb/bucket "nippy"}
+                                       "insects-two" {::cb/encoder :json
+                                                  ::cb/bucket "json"} 
+                                       "fruit-two" {::cb/encoder :nippy
+                                                ::cb/bucket "nippy"}
                                        "bytes" {::cb/encoder :binary
                                                 ::cb/bucket "binary"}})]
     (component/system-map

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -21,7 +21,10 @@
                                        "fruit-two" {::cb/encoder :nippy
                                                 ::cb/bucket "nippy"}
                                        "bytes" {::cb/encoder :binary
-                                                ::cb/bucket "binary"}})]
+                                                ::cb/bucket "binary"}})
+        ;;config (assoc-in config [::cb/bucket-passwords "json"] "foo")
+        ]
+;;    (println config)
     (component/system-map
      :couch (cb/couchbase config))))
 

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -1,29 +1,23 @@
 (ns dev
-  (:require [com.stuartsierra.component :as component]
-            [clojure.tools.namespace.repl :refer [refresh refresh-all]]
+  (:require [clojure.tools.namespace.repl :refer [refresh refresh-all]]
+            [com.stuartsierra.component :as component]
+            [org.purefn.bridges.api :as kv]
+            [org.purefn.kurosawa.health :as health]
             [org.purefn.kurosawa.log.core :as klog]
-            [org.purefn.lebowski.core :as cb]
-            [org.purefn.bridges.api :as kv]))
+            [org.purefn.lebowski.core :as cb]))
 
 (defn default-system
   []
-  (let [config {::cb/hosts [;;TODO
-                            ]
-                ::cb/bucket-passwords {;;TODO
-                                       }
-                ::cb/namespaces {"animals" {::cb/encoder :edn
-                                            ::cb/bucket "edn"
-                                            ::cb/key-sets "json"}
-                                 "fruit" {::cb/encoder :nippy
-                                          ::cb/bucket "nippy"}
-                                 "bytes" {::cb/encoder :binary
-                                          ::cb/bucket "binary"}
-                                 "jobseeker-profile" {::cb/encoder :nippy
-                                                      ::cb/bucket  "nippy"}}
-                ::cb/initial-delay-ms 2
-                ::cb/busy-delay-ms 500
-                ::cb/busy-retries 3
-                ::cb/max-retries 10}]
+  (let [config (assoc (cb/default-config "aws-couchbase")
+                      ::cb/namespaces {"animals" {::cb/encoder :edn
+                                                  ::cb/bucket "edn"
+                                                  ::cb/key-sets "json"}
+                                       "insects" {::cb/encoder :json
+                                                  ::cb/bucket "json"} 
+                                       "fruit" {::cb/encoder :nippy
+                                                ::cb/bucket "nippy"}
+                                       "bytes" {::cb/encoder :binary
+                                                ::cb/bucket "binary"}})]
     (component/system-map
      :couch (cb/couchbase config))))
 
@@ -55,7 +49,7 @@
   (init)
   #_(klog/init-dev-logging)         ;; high-level and low-level to console.
   (klog/init-dev-logging system)    ;; high-level only.
-  (klog/set-level :debug)
+  ;;(klog/set-level :debug)
   #_(klog/init-prod-logging system) ;; high-level to console, low-level to files.
   (start)
   :ready)

--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,8 @@
   :dependencies [[org.clojure/clojure "1.9.0-alpha16"]
                  [com.stuartsierra/component "0.3.2"]
                  
-                 [org.purefn/kurosawa.core "2.0.10"]
-                 [org.purefn/kurosawa.log "2.0.10"]
+                 [org.purefn/kurosawa.core "2.0.11"]
+                 [org.purefn/kurosawa.log "2.0.11"]
                  [org.purefn/bridges "1.13.0"]
 
                  ;; silence noisy internal couchbase logs

--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,8 @@
   :dependencies [[org.clojure/clojure "1.9.0-alpha16"]
                  [com.stuartsierra/component "0.3.2"]
                  
-                 [org.purefn/kurosawa.core "2.0.5"]
-                 [org.purefn/kurosawa.log "2.0.5"]
+                 [org.purefn/kurosawa.core "2.0.10"]
+                 [org.purefn/kurosawa.log "2.0.10"]
                  [org.purefn/bridges "1.13.0"]
 
                  ;; silence noisy internal couchbase logs
@@ -23,6 +23,10 @@
                  [com.cemerick/url "0.1.1"]
                  [clj-http "3.5.0"]
                  [cheshire "5.7.1"]]
+  
+  :deploy-repositories
+  [["releases" {:url "https://clojars.org/repo/" :creds :gpg}]]
+
    :profiles
   {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]]
          :jvm-opts ["-Xmx2g"]

--- a/src/org/purefn/lebowski/core.clj
+++ b/src/org/purefn/lebowski/core.clj
@@ -15,6 +15,7 @@
             [org.purefn.kurosawa.log.core :as klog]
             [org.purefn.kurosawa.log.protocol :as log-proto]
             [org.purefn.kurosawa.result :refer :all]
+            [org.purefn.kurosawa.transform :as xform]
             [org.purefn.kurosawa.util :as util]
             [org.purefn.lebowski.encoder.api :as encoder]
             [org.purefn.lebowski.encoder.binary-encoder :refer [binary-encoder]]
@@ -299,11 +300,9 @@
                         :nippy (nippy-encoder)
                         :binary (binary-encoder)
                         :json (json-encoder)}
-              health-keys (->> namespaces
-                               (map (juxt (comp ::bucket val)
-                                          identity))
-                               (into {})
-                               (map (juxt (comp first val)
+              health-keys (->> (vec namespaces)
+                               (xform/distinct-by (comp ::bucket val))
+                               (map (juxt first
                                           (constantly (str (UUID/randomUUID))))))]
 
           (doseq [[nname {:keys [::bucket ::key-sets]}] namespaces]

--- a/src/org/purefn/lebowski/core.clj
+++ b/src/org/purefn/lebowski/core.clj
@@ -51,7 +51,6 @@
 (defn- reason
   "The high-level reason for the failure."
   [ex]
-  (println ex)
   (cond
     (instance? clojure.lang.ExceptionInfo ex) (::api/reason (ex-data ex)
                                                             ::api/fatal)

--- a/src/org/purefn/lebowski/core.clj
+++ b/src/org/purefn/lebowski/core.clj
@@ -259,7 +259,7 @@
 ;;------------------------------------------------------------------------------
 
 (defrecord Couchbase
-    [config cluster buckets encoders]
+    [config cluster buckets encoders health-keys]
   
   component/Lifecycle
   (start [this]

--- a/src/org/purefn/lebowski/core.clj
+++ b/src/org/purefn/lebowski/core.clj
@@ -665,12 +665,16 @@
   (healthy? [this]
     (->> (:health-keys this)
          (map (fn [[ns k]]
-                (cache/swap-in
-                 this ns k
-                 (fn [_]
-                   {:uuids (repeatedly (rand-int 5) (comp str #(UUID/randomUUID)))})
-                 60)))
-         (every? some?))))
+                (if (cache/swap-in
+                     this ns k
+                     (fn [_]
+                       {:uuids (repeatedly (rand-int 5) (comp str #(UUID/randomUUID)))})
+                     60)
+                  true
+                  (do (log/error "Health check failed!"
+                                 {:namespace ns})
+                      false))))
+         (every? true?))))
 
 
 ;;------------------------------------------------------------------------------

--- a/src/org/purefn/lebowski/core.clj
+++ b/src/org/purefn/lebowski/core.clj
@@ -670,9 +670,9 @@
                 (cache/swap-in
                  this ns k
                  (fn [_]
-                   (vec (repeatedly (rand-int 5) #(UUID/randomUUID))))
-                 60))
-              ))))
+                   {:uuids (repeatedly (rand-int 5) (comp str #(UUID/randomUUID)))})
+                 60)))
+         (every? some?))))
 
 
 ;;------------------------------------------------------------------------------

--- a/src/org/purefn/lebowski/core.clj
+++ b/src/org/purefn/lebowski/core.clj
@@ -300,10 +300,10 @@
                         :binary (binary-encoder)
                         :json (json-encoder)}
               health-keys (->> namespaces
-                               (map (juxt (comp ::bucket second)
+                               (map (juxt (comp ::bucket val)
                                           identity))
                                (into {})
-                               (map (juxt (comp first second)
+                               (map (juxt (comp first val)
                                           (constantly (str (UUID/randomUUID))))))]
 
           (doseq [[nname {:keys [::bucket ::key-sets]}] namespaces]

--- a/src/org/purefn/lebowski/encoder/binary_encoder.clj
+++ b/src/org/purefn/lebowski/encoder/binary_encoder.clj
@@ -7,7 +7,32 @@
             [org.purefn.lebowski.encoder.protocol :as proto]
             [org.purefn.lebowski.encoder.common :as common])
   (:import [com.couchbase.client.java.document BinaryDocument]
-           [com.couchbase.client.deps.io.netty.buffer Unpooled ByteBuf]))
+           [com.couchbase.client.deps.io.netty.buffer Unpooled ByteBuf]
+           [java.io Serializable ByteArrayOutputStream ObjectOutputStream]))
+
+;;------------------------------------------------------------------------------
+;; Helpers
+;;------------------------------------------------------------------------------
+
+(defn serializable? [v]
+  (instance? Serializable v))
+
+(defn serialize 
+  "Serializes value, returns a byte array"
+  [v]
+  (let [buff (ByteArrayOutputStream. 1024)]
+    (with-open [dos (ObjectOutputStream. buff)]
+      (.writeObject dos v))
+    (.toByteArray buff)))
+
+(defn as-bytes
+  [v]
+  (cond
+    (bytes? v) v
+    (serializable? v) (serialize v)
+    :else (throw (ex-info "Value does not implement Serializable"
+                          {:value v
+                           :type (type v)}))))
 
 ;;------------------------------------------------------------------------------
 ;; Component. 
@@ -22,12 +47,14 @@
     (BinaryDocument/create ^String id nil ^Long cas))
   
   (encode [_ id value]
-    (->> (Unpooled/copiedBuffer value)
+    (->> (as-bytes value)
+         (Unpooled/copiedBuffer)
          (.retain)
          (BinaryDocument/create id)))
   
   (encode-versioned [_ id value cas]
-    (->> (Unpooled/copiedBuffer value)
+    (->> (as-bytes value)
+         (Unpooled/copiedBuffer)
          (.retain)
          ((fn [bs] (BinaryDocument/create ^String id
                                           ^ByteBuf bs


### PR DESCRIPTION
- Alphabetized the imports in `core.clj`
- Added a generic binary encoder for `binary` bucket for anything implementing `java.io.Serializable`
- Health check fns, one for each connected bucket which has a namespace mapped to it.