### PR TITLE
Success or throw

### DIFF
--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -66,3 +66,18 @@
   []
   (stop)
   (refresh :after `go))
+
+;; this much concurrency on the same key creates the failure mode (at least on the
+;; cluster I'm testing againt) of CAS mismatches and retries exhausting.  An exception
+;; is properly thrown.
+
+(defn create-cas-mismatch
+  []
+  (->> (range 20)
+       (pmap (fn [i]
+               (kv/swap-in (:couch system)
+                           "fruit"
+                           "cas"
+                           (fn [_]
+                             (Thread/sleep 600)
+                             i))))))

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.purefn/lebowski "1.24.4-SNAPSHOT"
+(defproject org.purefn/lebowski "2.0.0-SNAPSHOT"
   :description "A Couchbase implementation of the Bridges protocols."
   :url "https://github.com/PureFnOrg/lebowski"
   :license {:name "Eclipse Public License"

--- a/src/org/purefn/lebowski/core.clj
+++ b/src/org/purefn/lebowski/core.clj
@@ -103,11 +103,12 @@
     (retry-generic couch f recovery)))
 
 (defn- success-or-throw
-  "Unwraps an result, throwing if `Failure`, and returning the underlying value
+  "Unwraps a result, throwing if `Failure`, and returning the underlying value
   if `Success`."
   [result]
-  (if-let [ex (failure result)]
-    (throw ex)
+  (if-let [f (failure result)]
+    (throw (or (and (instance? Exception f) f)
+               (ex-info "Unknown failure" {:failure f})))
     (success result)))
 
 ;;------------------------------------------------------------------------------

--- a/src/org/purefn/lebowski/core.clj
+++ b/src/org/purefn/lebowski/core.clj
@@ -107,7 +107,7 @@
   if `Success`."
   [result]
   (if-let [f (failure result)]
-    (throw (or (and (instance? Exception f) f)
+    (throw (or (and (instance? Throwable f) f)
                (ex-info "Unknown failure" {:failure f})))
     (success result)))
 


### PR DESCRIPTION
We have seen some nasty failure modes resulting from KV methods returning `nil` representing an error, particularly in CRUD cycles from the web layer.

In an ideal world we'd have used the `*` API to compose around `Success`/`Failure`, but most (all?) usages in our code base have not done this.

To mitigate this, I'm proposing throwing on a final failure, instead of silently returning `nil`.